### PR TITLE
Fixed typo in strings.xml

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="wallet_card_stock_price">\@ %.2f/%s</string>
     <string name="wallet_card_test_network">Test network</string>
     <string name="wallet_card_backup_title">Action required: not backed up</string>
-    <string name="wallet_card_backup_description">If you loose this device you will loose your account and all your funds forever.</string>
+    <string name="wallet_card_backup_description">If you lose this device you will lose your account and all your funds forever.</string>
     <string name="wallet_card_backed_up">Backed up</string>
     <string name="wallet_toolbar_buy_ether">Buy ether</string>
     <string name="wallet_header_balances_title">Tokens</string>


### PR DESCRIPTION
Loose definition:
`not firmly or tightly fixed in place; detached or able to be detached.`

Lose definition:
`become unable to find (something or someone)`